### PR TITLE
Greatly simplified proxy/logic interaction

### DIFF
--- a/ProxyContractERC20/contracts/Logic1.sol
+++ b/ProxyContractERC20/contracts/Logic1.sol
@@ -7,49 +7,15 @@ pragma solidity ^0.4.24;
  */
 contract Logic1 {
 
-    ProxyInterface public proxyContract;
-
-    modifier onlyProxy() {
-        require(msg.sender == address(proxyContract), "This function can only be called by the proxy");
-        _;
-    }
-
     /**
-     * @dev Creates the reference to the deployed proxy contract using the ProxyInterface
-     *      and the passed in proxy address. Calls a function on the proxy contract to
-     *      update its reference to this contract.
-     */
-    constructor(address theProxyAddress) public {
-        proxyContract = ProxyInterface(theProxyAddress);
-        proxyContract.newLogicDeployed(address(this));
-    }
-
-    /**
-     * @dev This function takes in a value, and converts it to another value 
-     *      (the amount of tokens to be awarded based on the parameter) and then
-     *      passes this value back to the proxy contract for token minting.
+     * @dev Intended to be used by proxy contracts, returns a value calculated by
+     *      theAmount
      * @param theAmount The value to redeem.
      */
-    function redeem(uint256 theAmount) public onlyProxy() {
-
+    function redeem(uint256 theAmount) pure public returns (uint256) {
         // Any conversion math or gathering data from oracles that
         // effects the conversion rate or amount to tokens goes here...
-        uint256 tokensToAward = theAmount * 2;
-
-
-        // Call the proxy contract to update the users amount.
-        proxyContract.redeemTokens(tokensToAward);
+        
+        return theAmount * 2;
     }
-}
-
-/**
- * @title ProxyInterface
- * @dev This interface is so the logic contract knows the functions it can call on 
- *      the proxy contract. The Logic contract can then hold a reference to the 
- *      actual deployed proxy contract and call methods on it with only the proxy 
- *      contract's address.
- */
-interface ProxyInterface {
-    function newLogicDeployed(address theLogicAddress) external;
-    function redeemTokens(uint256 theTokensToAward) external;
 }

--- a/ProxyContractERC20/logic2/3_deploy_logic2.js
+++ b/ProxyContractERC20/logic2/3_deploy_logic2.js
@@ -1,6 +1,22 @@
 var Proxy = artifacts.require("Proxy");
 var Logic2 = artifacts.require("Logic2");
 
-module.exports = function(deployer) {
-    deployer.deploy(Logic2, Proxy.address);
+module.exports = async function(deployer) {
+    let logicInstance;
+
+    await Promise.all([
+      deployer.deploy(Logic2)
+    ]);
+  
+    instances = await Promise.all([
+      Proxy.deployed(),
+      Logic2.deployed()
+    ])
+  
+    proxyInstance = instances[0];
+    logicInstance = instances[1];
+  
+    results = await Promise.all([
+      proxyInstance.updateLogicAddress(logicInstance.address),
+    ]);
 };

--- a/ProxyContractERC20/logic2/Logic2.sol
+++ b/ProxyContractERC20/logic2/Logic2.sol
@@ -4,16 +4,10 @@ import "./Logic1.sol";
 
 /**
  * @title Logic2
- * @dev A logic contract which is meant to be called by a proxy contract, do some calculations
- *      (logic), then return a value. This logic contract changes the redeem method to return
- *      a new value.
+ * @dev A logic contract which is meant to be called by a proxy contract, do some calculations, then return a value. 
+ *      Specifically, this logic contract changes the redeem method to return a new value.
  */
 contract Logic2 is Logic1 {
-
-    /**
-     * @dev Call the parents constructor with theProxyAddress.
-     */
-    constructor(address theProxyAddress) Logic1(theProxyAddress) public {}
 
     /**
      * @dev This function takes in a value, and converts it to another value 
@@ -21,13 +15,10 @@ contract Logic2 is Logic1 {
      *      passes this value back to the proxy contract for token minting.
      * @param theAmount The value to redeem.
      */
-    function redeem(uint theAmount) public onlyProxy() {
+    function redeem(uint theAmount) pure public returns (uint256) {
 
-        // The key difference is we are multiplying theAmount by 10 now.
-        uint tokensToAward = theAmount * 10;
-
-
-        // Call the proxy contract to update the users amount.
-        proxyContract.redeemTokens(tokensToAward);
+        // The key difference is we are multiplying theAmount by 10 now
+        // instead of 2.
+        return theAmount * 10;
     }
 }

--- a/ProxyContractERC20/logic2/TestLogic2RealWorld.sol
+++ b/ProxyContractERC20/logic2/TestLogic2RealWorld.sol
@@ -15,10 +15,10 @@ contract TestLogic2RealWorld {
 
     function testRedeem() public {
         proxy.redeem(20);
-        Assert.equal(200, proxy.getBalance(), "Single redeem call failed");
+        Assert.equal(200, proxy.balanceOf(msg.sender), "Single redeem call failed");
         
         proxy.redeem(30);
         proxy.redeem(1);
-        Assert.equal(510, proxy.getBalance(), "Multiple redeem calls failed");
+        Assert.equal(510, proxy.balanceOf(msg.sender), "Multiple redeem calls failed");
     }
 }

--- a/ProxyContractERC20/logic2/TestLogic2TestEnv.sol
+++ b/ProxyContractERC20/logic2/TestLogic2TestEnv.sol
@@ -13,15 +13,16 @@ contract TestLogic2TestEnv {
     // Create and deploy a new instance of Proxy and Logic2 before each test.
     function beforeEach() public {
         proxy = new Proxy();
-        logic2 = new Logic2(address(proxy));
+        logic2 = new Logic2();
+        proxy.updateLogicAddress(address(logic2));
     }
 
     function testRedeem() public {
         proxy.redeem(20);
-        Assert.equal(200, proxy.getBalance(), "Single redeem call failed");
+        Assert.equal(200, proxy.balanceOf(msg.sender), "Single redeem call failed");
         
         proxy.redeem(30);
         proxy.redeem(1);
-        Assert.equal(510, proxy.getBalance(), "Multiple redeem calls failed");
+        Assert.equal(510, proxy.balanceOf(msg.sender), "Multiple redeem calls failed");
     }
 }

--- a/ProxyContractERC20/migrations/2_deploy_contracts.js
+++ b/ProxyContractERC20/migrations/2_deploy_contracts.js
@@ -1,8 +1,23 @@
 var Proxy = artifacts.require("Proxy");
 var Logic1 = artifacts.require("Logic1");
 
-module.exports = function(deployer) {
-    deployer.deploy(Proxy).then(function() {
-        return deployer.deploy(Logic1, Proxy.address);
-    });
+module.exports = async function(deployer) {
+    let proxyInstance, logicInstance;
+
+    await Promise.all([
+      deployer.deploy(Proxy),
+      deployer.deploy(Logic1)
+    ]);
+  
+    instances = await Promise.all([
+      Proxy.deployed(),
+      Logic1.deployed()
+    ])
+  
+    proxyInstance = instances[0];
+    logicInstance = instances[1];
+  
+    results = await Promise.all([
+      proxyInstance.updateLogicAddress(logicInstance.address),
+    ]);
 };

--- a/ProxyContractERC20/test/TestLogic1TestEnv.sol
+++ b/ProxyContractERC20/test/TestLogic1TestEnv.sol
@@ -13,7 +13,8 @@ contract TestLogic1TestEnv {
     // Create and deploy a new instance of Proxy and Logic1 before each test.
     function beforeEach() public {
         proxy = new Proxy();
-        logic1 = new Logic1(address(proxy));
+        logic1 = new Logic1();
+        proxy.updateLogicAddress(address(logic1));
     }
 
     function testRedeem() public {

--- a/ProxyContractERC20/test/TestProxyERC20Spec.sol
+++ b/ProxyContractERC20/test/TestProxyERC20Spec.sol
@@ -18,7 +18,8 @@ contract TestProxyERC20Spec {
     // Create and deploy a new instance of Proxy and Logic1 before each test.
     function beforeEach() public {
         proxy = new Proxy();
-        logic1 = new Logic1(address(proxy));
+        logic1 = new Logic1();
+        proxy.updateLogicAddress(address(logic1));
     }
 
     function testBalanceOf() public {


### PR DESCRIPTION
The proxy contract now uses the return value of the call to the logic contract instead of the logic contract calling the proxy contract.